### PR TITLE
Validate binding value changed on componentUpdated

### DIFF
--- a/src/directives/bsl-directive.js
+++ b/src/directives/bsl-directive.js
@@ -14,6 +14,10 @@ export default {
         }
     },
     componentUpdated: (el, binding) => {
+        if (binding.oldValue === binding.value) {
+            return;
+        }
+
         if (binding.arg && binding.arg === RESERVE_SCROLL_BAR_GAP && binding.value) {
             disableBodyScroll(el, options);
         } else if (binding.value) {


### PR DESCRIPTION
Component changes that are unrelated to the directive binding will trigger componentUpdate and pile up BSL events breaking scroll restoration