### PR TITLE
fix reserveScrollBarGab by change  camelCase directive to kebab-case

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ export default {
 Reserves the width of the scrollbar and prevents the unpleasant flickering effect that can occur when locking the body scroll.<br>
 More info [here](https://github.com/willmcpo/body-scroll-lock#options).
 
-To enable the `reserveScrollBarGap` option add `:reserveScrollBarGap` after `v-body-scroll-lock` or `v-bsl`.<br>
-Example: `v-body-scroll-lock:reserveScrollBarGap="modalIsOpen"`.
+To enable the `reserveScrollBarGap` option add `:reserve-scroll-bar-gap` after `v-body-scroll-lock` or `v-bsl`.<br>
+Example: `v-body-scroll-lock:reserve-scroll-bar-gap="modalIsOpen"`.
 
 <a name="issues"></a>
 ## Issues

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,7 +1,7 @@
 <template>
   <div id="app">
       <transition name="fade">
-          <Modal v-body-scroll-lock:reserveScrollBarGap="modalIsOpen"
+          <Modal v-body-scroll-lock:reserve-scroll-bar-gap="modalIsOpen"
                  v-show="modalIsOpen"
                  :modal-is-open="modalIsOpen"
                  @closeModal="closeModal" />

--- a/src/directives/bsl-directive.js
+++ b/src/directives/bsl-directive.js
@@ -1,6 +1,6 @@
 import { disableBodyScroll, enableBodyScroll } from 'body-scroll-lock';
 
-const RESERVE_SCROLL_BAR_GAP = 'reserveScrollBarGap';
+const RESERVE_SCROLL_BAR_GAP = 'reserve-scroll-bar-gap';
 const options = {
     reserveScrollBarGap: true
 };


### PR DESCRIPTION
Vue by default changes camelCase arguments to lowercase, so this condition 
`binding.arg === RESERVE_SCROLL_BAR_GAP` 

will look like

`'reservescrollbargap' === 'reserveScrollBarGap' // false`

So `options` can't be used in any way.

We just need to use kebab-case in directives.